### PR TITLE
Add asynchronous I/O compatibility layer and asyncio support

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''
-lltest.py - Example file system for pyfuse3.
+hello.py - Example file system for pyfuse3.
 
 This program presents a static file system containing a single file.
 
@@ -140,7 +140,7 @@ def main():
 
     testfs = TestFs()
     fuse_options = set(pyfuse3.default_options)
-    fuse_options.add('fsname=lltest')
+    fuse_options.add('fsname=hello')
     if options.debug_fuse:
         fuse_options.add('debug')
     pyfuse3.init(testfs, options.mountpoint, fuse_options)

--- a/examples/hello_asyncio.py
+++ b/examples/hello_asyncio.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+hello_asyncio.py - Example file system for pyfuse3 using asyncio.
+
+This program presents a static file system containing a single file.
+
+Copyright © 2015 Nikolaus Rath <Nikolaus.org>
+Copyright © 2015 Gerion Entrup.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+import os
+import sys
+
+# If we are running from the pyfuse3 source directory, try
+# to load the module from there first.
+basedir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+if (os.path.exists(os.path.join(basedir, 'setup.py')) and
+    os.path.exists(os.path.join(basedir, 'src', 'pyfuse3.pyx'))):
+    sys.path.insert(0, os.path.join(basedir, 'src'))
+
+from argparse import ArgumentParser
+import asyncio
+import stat
+import logging
+import errno
+import pyfuse3
+
+try:
+    import faulthandler
+except ImportError:
+    pass
+else:
+    faulthandler.enable()
+
+log = logging.getLogger(__name__)
+
+class TestFs(pyfuse3.Operations):
+    def __init__(self):
+        super(TestFs, self).__init__()
+        self.hello_name = b"message"
+        self.hello_inode = pyfuse3.ROOT_INODE+1
+        self.hello_data = b"hello world\n"
+
+    async def getattr(self, inode, ctx=None):
+        entry = pyfuse3.EntryAttributes()
+        if inode == pyfuse3.ROOT_INODE:
+            entry.st_mode = (stat.S_IFDIR | 0o755)
+            entry.st_size = 0
+        elif inode == self.hello_inode:
+            entry.st_mode = (stat.S_IFREG | 0o644)
+            entry.st_size = len(self.hello_data)
+        else:
+            raise pyfuse3.FUSEError(errno.ENOENT)
+
+        stamp = int(1438467123.985654 * 1e9)
+        entry.st_atime_ns = stamp
+        entry.st_ctime_ns = stamp
+        entry.st_mtime_ns = stamp
+        entry.st_gid = os.getgid()
+        entry.st_uid = os.getuid()
+        entry.st_ino = inode
+
+        return entry
+
+    async def lookup(self, parent_inode, name, ctx=None):
+        if parent_inode != pyfuse3.ROOT_INODE or name != self.hello_name:
+            raise pyfuse3.FUSEError(errno.ENOENT)
+        return self.getattr(self.hello_inode)
+
+    async def opendir(self, inode, ctx):
+        if inode != pyfuse3.ROOT_INODE:
+            raise pyfuse3.FUSEError(errno.ENOENT)
+        return inode
+
+    async def readdir(self, fh, start_id, token):
+        assert fh == pyfuse3.ROOT_INODE
+
+        # only one entry
+        if start_id == 0:
+            pyfuse3.readdir_reply(
+                token, self.hello_name, await self.getattr(self.hello_inode), 1)
+        return
+
+    async def open(self, inode, flags, ctx):
+        if inode != self.hello_inode:
+            raise pyfuse3.FUSEError(errno.ENOENT)
+        if flags & os.O_RDWR or flags & os.O_WRONLY:
+            raise pyfuse3.FUSEError(errno.EPERM)
+        return inode
+
+    async def read(self, fh, off, size):
+        assert fh == self.hello_inode
+        return self.hello_data[off:off+size]
+
+def init_logging(debug=False):
+    formatter = logging.Formatter('%(asctime)s.%(msecs)03d %(threadName)s: '
+                                  '[%(name)s] %(message)s', datefmt="%Y-%m-%d %H:%M:%S")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    if debug:
+        handler.setLevel(logging.DEBUG)
+        root_logger.setLevel(logging.DEBUG)
+    else:
+        handler.setLevel(logging.INFO)
+        root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(handler)
+
+def parse_args():
+    '''Parse command line'''
+
+    parser = ArgumentParser()
+
+    parser.add_argument('mountpoint', type=str,
+                        help='Where to mount the file system')
+    parser.add_argument('--debug', action='store_true', default=False,
+                        help='Enable debugging output')
+    parser.add_argument('--debug-fuse', action='store_true', default=False,
+                        help='Enable FUSE debugging output')
+    return parser.parse_args()
+
+
+def main():
+    options = parse_args()
+    init_logging(options.debug)
+
+    testfs = TestFs()
+    fuse_options = set(pyfuse3.default_options)
+    fuse_options.add('fsname=hello_asyncio')
+    if options.debug_fuse:
+        fuse_options.add('debug')
+    pyfuse3.init(testfs, options.mountpoint, fuse_options)
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(pyfuse3.main(aio='asyncio'))
+    except:
+        pyfuse3.close(unmount=False)
+        raise
+    finally:
+        loop.close()
+
+    pyfuse3.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/aio.pxi
+++ b/src/aio.pxi
@@ -1,0 +1,105 @@
+'''
+aio.pxi
+
+asyncio/Trio compatibility layer for pyfuse3
+
+Copyright © 2018 JustAnotherArchivist, Nikolaus Rath <Nikolaus.org>
+
+This file is part of pyfuse3. This work may be distributed under
+the terms of the GNU LGPL.
+'''
+
+import asyncio
+import contextlib
+import sys
+try:
+    import trio
+except ImportError:
+    trio = None
+
+
+_aio_implementation = 'trio' # Possible values: 'asyncio' or 'trio'
+_aio = None
+_aio_read_lock = None
+
+
+###########
+# asyncio #
+###########
+
+class AsyncioCompatibilityLayer:
+    def __repr__(self):
+        return '<pyfuse3 asyncio compatibility layer>'
+_asyncio_layer = AsyncioCompatibilityLayer()
+
+class AsyncioHazmatCompatibilityLayer:
+    def __repr__(self):
+        return '<pyfuse3 asyncio hazmat compatibility layer>'
+_asyncio_layer.hazmat = AsyncioHazmatCompatibilityLayer()
+
+async def _wait_readable_asyncio(fd):
+    future = asyncio.Future()
+    loop = asyncio.get_event_loop()
+    loop.add_reader(fd, future.set_result, None)
+    future.add_done_callback(lambda f: loop.remove_reader(fd))
+    await future
+_asyncio_layer.hazmat.wait_readable = _wait_readable_asyncio
+
+def _current_task_asyncio():
+    if sys.version_info < (3, 7):
+        return asyncio.Task.current_task()
+    else:
+        return asyncio.current_task()
+_asyncio_layer.hazmat.current_task = _current_task_asyncio
+
+class _AsyncioNursery:
+    async def __aenter__(self):
+        self.tasks = set()
+        return self
+
+    def start_soon(self, func, *args, name = None):
+        if sys.version_info < (3, 7):
+            task = asyncio.ensure_future(func(*args))
+        else:
+            task = asyncio.create_task(func(*args))
+        task.name = name
+        self.tasks.add(task)
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        # Wait for tasks to finish
+        while len(self.tasks):
+            done, pending = await asyncio.wait(tuple(self.tasks)) # Create a copy of the task list to ensure that it's not a problem when self.tasks is modified
+            for task in done:
+                self.tasks.discard(task)
+            # We waited for ALL_COMPLETED (default value of 'when' arg to asyncio.wait), so all tasks should be completed. If that's not the case, something's seriously wrong.
+            assert len(pending) == 0
+
+def _open_nursery_asyncio():
+    return _AsyncioNursery()
+_asyncio_layer.open_nursery = _open_nursery_asyncio
+
+
+########
+# Trio #
+########
+
+# Nothing needed, we simply set _aio = trio below
+
+
+##############
+# Management #
+##############
+
+def _set_aio(aio_implementation):
+    if aio_implementation not in ('asyncio', 'trio'):
+        raise ValueError('Invalid aio')
+    if aio_implementation == 'trio' and trio is None:
+        raise RuntimeError('trio unavailable')
+    global _aio_implementation, _aio, _aio_read_lock
+    _aio_implementation = aio_implementation
+    if aio_implementation == 'asyncio':
+        _aio_read_lock = asyncio.Lock()
+        _aio = _asyncio_layer
+    else:
+        _aio_read_lock = trio.Lock()
+        _aio = trio

--- a/src/aio.pxi
+++ b/src/aio.pxi
@@ -27,15 +27,15 @@ _aio_read_lock = None
 # asyncio #
 ###########
 
-class AsyncioCompatibilityLayer:
+class _AsyncioCompatibilityLayer:
     def __repr__(self):
         return '<pyfuse3 asyncio compatibility layer>'
-_asyncio_layer = AsyncioCompatibilityLayer()
+_asyncio_layer = _AsyncioCompatibilityLayer()
 
-class AsyncioHazmatCompatibilityLayer:
+class _AsyncioHazmatCompatibilityLayer:
     def __repr__(self):
         return '<pyfuse3 asyncio hazmat compatibility layer>'
-_asyncio_layer.hazmat = AsyncioHazmatCompatibilityLayer()
+_asyncio_layer.hazmat = _AsyncioHazmatCompatibilityLayer()
 
 async def _wait_readable_asyncio(fd):
     future = asyncio.Future()
@@ -73,10 +73,7 @@ class _AsyncioNursery:
                 self.tasks.discard(task)
             # We waited for ALL_COMPLETED (default value of 'when' arg to asyncio.wait), so all tasks should be completed. If that's not the case, something's seriously wrong.
             assert len(pending) == 0
-
-def _open_nursery_asyncio():
-    return _AsyncioNursery()
-_asyncio_layer.open_nursery = _open_nursery_asyncio
+_asyncio_layer.open_nursery = _AsyncioNursery
 
 
 ########

--- a/src/internal.pxi
+++ b/src/internal.pxi
@@ -183,11 +183,9 @@ cdef class _WorkerData:
 
     cdef int task_count
     cdef int task_serial
-    cdef object read_lock
     cdef int active_readers
 
     def __init__(self):
-        self.read_lock = trio.Lock()
         self.active_readers = 0
 
     cdef get_name(self):
@@ -197,12 +195,12 @@ cdef class _WorkerData:
 cdef _WorkerData worker_data = _WorkerData()
 
 async def _wait_fuse_readable():
-    #name = trio.hazmat.current_task().name
+    #name = _aio.hazmat.current_task().name
     worker_data.active_readers += 1
     #log.debug('%s: Waiting for read lock...', name)
-    async with worker_data.read_lock:
+    async with _aio_read_lock:
         #log.debug('%s: Waiting for fuse fd to become readable...', name)
-        await trio.hazmat.wait_readable(session_fd)
+        await _aio.hazmat.wait_readable(session_fd)
 
     worker_data.active_readers -= 1
     #log.debug('%s: fuse fd readable, unparking next task.', name)
@@ -213,7 +211,7 @@ async def _session_loop(nursery, int min_tasks, int max_tasks):
     cdef int res
     cdef fuse_buf buf
 
-    name = trio.hazmat.current_task().name
+    name = _aio.hazmat.current_task().name
 
     buf.mem = NULL
     buf.size = 0

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -37,11 +37,15 @@ def name_generator(__ctr=[0]):
     __ctr[0] += 1
     return 'testfile_%d' % __ctr[0]
 
-def test_lltest(tmpdir):
+@pytest.fixture(params=['asyncio', 'trio'])
+def aio(request):
+    return request.param
+
+def test_hello(tmpdir, aio):
     mnt_dir = str(tmpdir)
     cmdline = [sys.executable,
-               os.path.join(basename, 'examples', 'lltest.py'),
-               mnt_dir ]
+               os.path.join(basename, 'examples', 'hello_asyncio.py' if aio == 'asyncio' else 'hello.py'),
+               mnt_dir]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:
@@ -66,7 +70,7 @@ def test_tmpfs(tmpdir):
     mnt_dir = str(tmpdir)
     cmdline = [sys.executable,
                os.path.join(basename, 'examples', 'tmpfs.py'),
-               mnt_dir ]
+               mnt_dir]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:
@@ -95,7 +99,7 @@ def test_passthroughfs(tmpdir):
     src_dir = str(tmpdir.mkdir('src'))
     cmdline = [sys.executable,
                os.path.join(basename, 'examples', 'passthroughfs.py'),
-               src_dir, mnt_dir ]
+               src_dir, mnt_dir]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -37,15 +37,12 @@ def name_generator(__ctr=[0]):
     __ctr[0] += 1
     return 'testfile_%d' % __ctr[0]
 
-@pytest.fixture(params=['asyncio', 'trio'])
-def aio(request):
-    return request.param
-
-def test_hello(tmpdir, aio):
+@pytest.mark.parametrize('filename', ('hello.py', 'hello_asyncio.py'))
+def test_hello(tmpdir, filename):
     mnt_dir = str(tmpdir)
     cmdline = [sys.executable,
-               os.path.join(basename, 'examples', 'hello_asyncio.py' if aio == 'asyncio' else 'hello.py'),
-               mnt_dir]
+               os.path.join(basename, 'examples', filename),
+               mnt_dir ]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:
@@ -70,7 +67,7 @@ def test_tmpfs(tmpdir):
     mnt_dir = str(tmpdir)
     cmdline = [sys.executable,
                os.path.join(basename, 'examples', 'tmpfs.py'),
-               mnt_dir]
+               mnt_dir ]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:
@@ -99,7 +96,7 @@ def test_passthroughfs(tmpdir):
     src_dir = str(tmpdir.mkdir('src'))
     cmdline = [sys.executable,
                os.path.join(basename, 'examples', 'passthroughfs.py'),
-               src_dir, mnt_dir]
+               src_dir, mnt_dir ]
     mount_process = subprocess.Popen(cmdline, stdin=subprocess.DEVNULL,
                                      universal_newlines=True)
     try:


### PR DESCRIPTION
This fixes #8 by introducing a compatibility layer for the asynchronous I/O (aio.pxi) which works for both asyncio and Trio.

I would like to mention that I saw some random errors on the teardown of `test_invalidate_entry`, which failed sometimes with an `AssertionError: Suspicious output to stderr (matched "error")` and a truncated traceback involving multiprocessing and `libgcc_s.so.1 must be installed for pthread_cancel to work`. I was able to reproduce this on master as well though, so that doesn't seem to be related to my changes.
On one occasion, `test_passthroughfs[trio]` failed with an assertion error on line 376 of `test_examples.py` where `st_mtime_ns` was slightly different (a few milliseconds difference); this seems to be very difficult to reproduce (only happened once in dozens of test runs) and probably depends on various things, and I also very much doubt it has anything to do with my code. The underlying FS in this case was a tmpfs.

Another thing worth mentioning because it might come up again is that it's fairly easy to freeze a test due to not handling the async implementation correctly. For example, I forgot to replace the `trio.sleep` inside the `setxattr` handler in `test_fs.py` at first, which caused those tests to lock up when running with asyncio because `trio.sleep` throws an exception when called from outside of `trio.run`. It simply started `test_invalidate_entry[asyncio]` and then sat there forever. For some reason, the process was in disk sleep and therefore unkillable. I had to abort the FUSE connection with `echo 1 > /sys/fs/fuse/connections/50/abort` to fix this and see the error message. It might be worth rewriting the test suite in a way that it can detect such failures instead of simply hanging, but I didn't look into how that would have to be done (might be quite tricky).

NB, I first had the compatibility layer in a pure-Python module `pyfuse3.aio`. This however required some modifications such as passing the `worker_data` and `session_fd` explicitly to the `wait_fuse_readable` method since it couldn't access them directly; also, the `active_readers` field of `WorkerData` had to be public for this to work. The code is preserved on the aio-py branch on my fork, but I think the code in the aio-c branch/this PR is a better solution (or at least more in line with how the rest of the pyfuse3 codebase works currently).