### PR TITLE
Add support for `fuse_file_info` struct in `Operations.open`

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -95,7 +95,7 @@ class TestFs(pyfuse3.Operations):
                 token, self.hello_name, await self.getattr(self.hello_inode), 1)
         return
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         if inode != self.hello_inode:
             raise pyfuse3.FUSEError(errno.ENOENT)
         if flags & os.O_RDWR or flags & os.O_WRONLY:

--- a/examples/hello_asyncio.py
+++ b/examples/hello_asyncio.py
@@ -97,7 +97,7 @@ class TestFs(pyfuse3.Operations):
                 token, self.hello_name, await self.getattr(self.hello_inode), 1)
         return
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         if inode != self.hello_inode:
             raise pyfuse3.FUSEError(errno.ENOENT)
         if flags & os.O_RDWR or flags & os.O_WRONLY:

--- a/examples/passthroughfs.py
+++ b/examples/passthroughfs.py
@@ -374,7 +374,7 @@ class Operations(pyfuse3.Operations):
         stat_.f_namemax = statfs.f_namemax - (len(root)+1)
         return stat_
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         if inode in self._inode_fd_map:
             fd = self._inode_fd_map[inode]
             self._fd_open_count[fd] += 1

--- a/examples/tmpfs.py
+++ b/examples/tmpfs.py
@@ -338,7 +338,7 @@ class Operations(pyfuse3.Operations):
 
         return stat_
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         # Yeah, unused arguments
         #pylint: disable=W0613
         self.inode_open_count[inode] += 1

--- a/src/_pyfuse3.py
+++ b/src/_pyfuse3.py
@@ -299,7 +299,7 @@ class Operations:
 
         raise FUSEError(errno.ENOSYS)
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         '''Open a inode *inode* with *flags*.
 
         *ctx* will be a `RequestContext` instance.
@@ -308,9 +308,16 @@ class Operations:
         :manpage:`open(2)` manpage and defined in the `os` module (with the
         exception of ``O_CREAT``, ``O_EXCL``, ``O_NOCTTY`` and ``O_TRUNC``)
 
+        *file_info* will be a dictionary containing the fields of the
+        ``fuse_file_info`` struct.
+
         This method must return an integer file handle. The file handle will be
         passed to the `read`, `write`, `flush`, `fsync` and `release` methods to
         identify the open file.
+
+        This method may additionally return a dictionary containing the writable
+        fields of ``fuse_file_info``, such as ``direct_info`` and
+        ``keep_cache``, which will then be copied back into the libfuse struct.
         '''
 
         raise FUSEError(errno.ENOSYS)

--- a/src/handlers.pxi
+++ b/src/handlers.pxi
@@ -382,14 +382,32 @@ async def fuse_open_async (_Container c):
     cdef int ret
 
     ctx = get_request_context(c.req)
+
+    # Cached file data does not need to be invalidated.
+    # http://article.gmane.org/gmane.comp.file-systems.fuse.devel/5325/
+    c.fi.keep_cache = 1
+
     try:
-        c.fi.fh = await operations.open(c.ino, c.fi.flags, ctx)
+        res = await operations.open(c.ino, c.fi.flags, ctx, c.fi)
     except FUSEError as e:
         ret = fuse_reply_err(c.req, e.errno)
     else:
-        # Cached file data does not need to be invalidated.
-        # http://article.gmane.org/gmane.comp.file-systems.fuse.devel/5325/
-        c.fi.keep_cache = 1
+        if isinstance(res, tuple):
+            if len(res) >= 2:
+                new_fi = res[1]
+                # Some trickery is required to prevent GCC from complaining
+                # about assignments to the fi bitfields.
+                if new_fi["direct_io"]:
+                    c.fi.direct_io = 1
+                else:
+                    c.fi.direct_io = 0
+                if new_fi["keep_cache"]:
+                    c.fi.keep_cache = 1
+                else:
+                    c.fi.keep_cache = 0
+            c.fi.fh = res[0]
+        else:
+            c.fi.fh = res
 
         ret = fuse_reply_open(c.req, &c.fi)
 

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -194,7 +194,7 @@ class Fs(pyfuse3.Operations):
                 token, self.hello_name, await self.getattr(self.hello_inode), 1)
         return
 
-    async def open(self, inode, flags, ctx):
+    async def open(self, inode, flags, ctx, file_info):
         if inode != self.hello_inode:
             raise pyfuse3.FUSEError(errno.ENOENT)
         if flags & os.O_RDWR or flags & os.O_WRONLY:


### PR DESCRIPTION
As it stands, pyfuse3 does not allow the `open` call to read or modify the `fuse_file_info` struct that is passed by libfuse. As a result, certain information about the call is unavailable, and options such as `keep_cache` and `direct_io` cannot be configured. In particular, the `direct_io` option is important for disabling kernel caching, which is required for filesystems that may be updated externally (e.g. sshfs).

This proposal solves this issue by passing the `fuse_file_info` struct to the `Operations.open` function, which Cython converts to a dictionary. In addition, the `Operations.open` method may also return a dictionary with the keys `keep_cache` and `direct_io`, which will then be copied back into the libfuse struct.

I'd be happy to implement any suggested alterations to the API here -- I wasn't quite sure what the best way would be.