### PR TITLE
Update pyfuse3.pyx

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -4,6 +4,12 @@
 
 .. currentmodule:: pyfuse3
 
+Release 3.x.y (TBD)
+==========================
+
+* Fix long-standing rounding error in file date handling when the nanosecond
+  part of file dates were > 999999500.
+
 
 Release 3.1.1 (2020-10-06)
 ==========================

--- a/src/pyfuse3.pyx
+++ b/src/pyfuse3.pyx
@@ -93,6 +93,8 @@ cdef object _notify_queue = None
 ROOT_INODE = FUSE_ROOT_ID
 __version__ = PYFUSE3_VERSION.decode('utf-8')
 
+_NANOS_PER_SEC = 1000000000
+
 # In the Cython source, we want the names to refer to the
 # C constants. Therefore, we assign through globals().
 g = globals()
@@ -286,29 +288,29 @@ cdef class EntryAttributes:
     @property
     def st_atime_ns(self):
         '''Time of last access in (integer) nanoseconds'''
-        return (int(self.attr.st_atime) * 10**9 + GET_ATIME_NS(self.attr))
+        return (int(self.attr.st_atime) * _NANOS_PER_SEC + GET_ATIME_NS(self.attr))
     @st_atime_ns.setter
     def st_atime_ns(self, val):
-        self.attr.st_atime = val / 10**9
-        SET_ATIME_NS(self.attr, val % 10**9)
+        self.attr.st_atime = (val // _NANOS_PER_SEC)
+        SET_ATIME_NS(self.attr, val % _NANOS_PER_SEC)
 
     @property
     def st_mtime_ns(self):
         '''Time of last modification in (integer) nanoseconds'''
-        return (int(self.attr.st_mtime) * 10**9 + GET_MTIME_NS(self.attr))
+        return (int(self.attr.st_mtime) * _NANOS_PER_SEC + GET_MTIME_NS(self.attr))
     @st_mtime_ns.setter
     def st_mtime_ns(self, val):
-        self.attr.st_mtime = val / 10**9
-        SET_MTIME_NS(self.attr, val % 10**9)
+        self.attr.st_mtime = val // _NANOS_PER_SEC
+        SET_MTIME_NS(self.attr, val % _NANOS_PER_SEC)
 
     @property
     def st_ctime_ns(self):
         '''Time of last inode modification in (integer) nanoseconds'''
-        return (int(self.attr.st_ctime) * 10**9 + GET_CTIME_NS(self.attr))
+        return (int(self.attr.st_ctime) * _NANOS_PER_SEC + GET_CTIME_NS(self.attr))
     @st_ctime_ns.setter
     def st_ctime_ns(self, val):
-        self.attr.st_ctime = val / 10**9
-        SET_CTIME_NS(self.attr, val % 10**9)
+        self.attr.st_ctime = val // _NANOS_PER_SEC
+        SET_CTIME_NS(self.attr, val % _NANOS_PER_SEC)
 
     @property
     def st_birthtime_ns(self):
@@ -319,15 +321,15 @@ cdef class EntryAttributes:
 
         # Use C macro to prevent compiler error on Linux
         # (where st_birthtime does not exist)
-        return int(GET_BIRTHTIME(self.attr) * 10**9
+        return int(GET_BIRTHTIME(self.attr) * _NANOS_PER_SEC
                     + GET_BIRTHTIME_NS(self.attr))
 
     @st_birthtime_ns.setter
     def st_birthtime_ns(self, val):
         # Use C macro to prevent compiler error on Linux
         # (where st_birthtime does not exist)
-        SET_BIRTHTIME(self.attr, val / 10**9)
-        SET_BIRTHTIME_NS(self.attr, val % 10**9)
+        SET_BIRTHTIME(self.attr, val // _NANOS_PER_SEC)
+        SET_BIRTHTIME_NS(self.attr, val % _NANOS_PER_SEC)
 
     # Pickling and copy support
     def __getstate__(self):

--- a/test/test_rounding.py
+++ b/test/test_rounding.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+test_rounding.py - Unit tests for pyfuse3.
+
+Copyright © 2020 Philip Warner <philipwarner.info>
+
+This file is part of pyfuse3. This work may be distributed under
+the terms of the GNU LGPL.
+'''
+
+if __name__ == '__main__':
+    import pytest
+    import sys
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+
+import pyfuse3
+from pyfuse3 import _NANOS_PER_SEC
+
+def test_rounding():
+    # Incorrect division previously reaulted in rounding errors for
+    # all dates.
+    entry = pyfuse3.EntryAttributes()
+
+    secs = 100*365*24*3600 + 999
+    nanos = _NANOS_PER_SEC - 1
+
+    total = secs * _NANOS_PER_SEC + nanos
+    
+    entry.st_atime_ns = total
+    entry.st_ctime_ns = total
+    entry.st_mtime_ns = total
+
+    assert entry.st_atime_ns == total
+    assert entry.st_ctime_ns == total
+    assert entry.st_mtime_ns == total


### PR DESCRIPTION
Fix rounding error on nanosecond based date values.

The floating point division results in rounding of high-precision nanosecond values. 

If you want me to add usint tests, let me know if I should clone an existing test, or add to an exiting one.