### PR TITLE
test: Use shutil.which() instead of external which(1) program

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -12,6 +12,7 @@ the terms of the GNU LGPL.
 import os
 import platform
 import pytest
+import shutil
 import stat
 import subprocess
 import time
@@ -29,11 +30,8 @@ def fuse_test_marker():
         return
     skip = lambda x: pytest.mark.skip(reason=x)
 
-    with subprocess.Popen(['which', 'fusermount'], stdout=subprocess.PIPE,
-                           universal_newlines=True) as which:
-        fusermount_path = which.communicate()[0].strip()
-
-    if not fusermount_path or which.returncode != 0:
+    fusermount_path = shutil.which('fusermount')
+    if fusermount_path is None:
         return skip("Can't find fusermount executable")
 
     if not os.path.exists('/dev/fuse'):


### PR DESCRIPTION
Use the Python stdlib shutil.which() function instead of calling the third-party which(1) program to locate fusermount.  This function is available since Python 3.3, and Gentoo is in process of deprecating which (which is entirely redundant to shell built-ins and known to be frequently abused).