### PR TITLE
Exclude developer-notes/ from contributing to repo's language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+developer-notes/** linguist-documentation


### PR DESCRIPTION
This should stop Github from detecting the language of this repository as HTML. See [linguist docs](https://github.com/github/linguist/blob/master/docs/overrides.md) for reference.