### PR TITLE
Expose primitive type subclasses even when not type-checking

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -4,6 +4,12 @@
 
 .. currentmodule:: pyfuse3
 
+Unreleased Changes
+==================
+
+* Expose primitive subclasses (e.g. ``InodeT``) even when not type-checking.
+
+
 Release 3.3.0 (2023-08-06)
 ==========================
 

--- a/src/pyfuse3.pyx
+++ b/src/pyfuse3.pyx
@@ -67,15 +67,12 @@ import os.path
 import sys
 import trio
 import threading
-import typing
 
 import _pyfuse3
 _pyfuse3.FUSEError = FUSEError
 
-from _pyfuse3 import Operations, async_wrapper
-
-if typing.TYPE_CHECKING:
-    from _pyfuse3 import FileHandleT, FileNameT, FlagT, InodeT, ModeT
+from _pyfuse3 import (Operations, async_wrapper, FileHandleT, FileNameT, FlagT,
+                      InodeT, ModeT)
 
 
 ##################


### PR DESCRIPTION
These are sometimes useful in `cast()` expressions, which requires them to be exposed at runtime.