### PR TITLE
test_examples: ignore xtime discrepancies less than 1s

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -437,5 +437,11 @@ def assert_same_stats(name1, name2):
                  'st_gid', 'st_size'):
         v1 = getattr(stat1, name)
         v2 = getattr(stat2, name)
-        assert  v1 == v2, 'Attribute {} differs by {} ({} vs {})'.format(
+
+        # Known bug, cf. https://github.com/libfuse/pyfuse3/issues/57
+        if name.endswith('_ns'):
+            tolerance = 999_999 # <1 second
+        else:
+            tolerance = 0
+        assert  abs(v1 - v2) <= tolerance, 'Attribute {} differs by {} ({} vs {})'.format(
             name, v1 - v2, v1, v2)


### PR DESCRIPTION
It's not clear where these come from, but we shouldn't have CI fail because of a known problem.

https://github.com/libfuse/pyfuse3/issues/57