### PR TITLE
Support FUSE clients without READDIRPLUS (fall back to plain readdir)

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -4,6 +4,18 @@
 
 .. currentmodule:: pyfuse3
 
+Unreleased Changes
+==================
+
+* pyfuse3 no longer aborts with "Kernel too old" when the FUSE connection lacks
+  ``FUSE_CAP_READDIRPLUS``, and now answers plain ``FUSE_READDIR`` requests in
+  addition to ``FUSE_READDIRPLUS``. This lets filesystems run under FUSE clients
+  that implement only plain readdir, such as gVisor's sentry (gVisor issue
+  #3404). Filesystems that track lookup counts must consult the new read-only
+  `ReaddirToken.plus` attribute: entries returned for a plain ``FUSE_READDIR``
+  take no kernel lookup reference and must not increase the lookup count. See
+  `~Operations.readdir`.
+
 pyfuse 3.5.0 (2026-05-13)
 =========================
 

--- a/examples/passthroughfs.py
+++ b/examples/passthroughfs.py
@@ -207,7 +207,10 @@ class Operations(pyfuse3.Operations):
                 continue
             if not pyfuse3.readdir_reply(token, fsencode(name), attr, ino):
                 break
-            self._add_path(attr.st_ino, os.path.join(path, name))
+            # A plain FUSE_READDIR (token.plus is False) takes no kernel lookup
+            # reference, so we must not bump the lookup count for it.
+            if token.plus:
+                self._add_path(attr.st_ino, os.path.join(path, name))
 
     async def unlink(self, parent_inode: InodeT, name: bytes, ctx: RequestContext) -> None:
         name_str = fsdecode(name)

--- a/rst/data.rst
+++ b/rst/data.rst
@@ -196,6 +196,13 @@
 
    An identifier for a particular `~Operations.readdir` invocation.
 
+   .. attribute:: plus
+
+      A read-only boolean indicating how the client requested the listing. If
+      True, the request was ``FUSE_READDIRPLUS`` and reported entries take a
+      kernel lookup reference; if False, it was a plain ``FUSE_READDIR`` and
+      they do not. See `~Operations.readdir` for the effect on lookup counts.
+
 .. autoclass:: PollHandle
 
    .. automethod:: notify

--- a/src/pyfuse3/__init__.pyi
+++ b/src/pyfuse3/__init__.pyi
@@ -39,7 +39,7 @@ StatDict = Mapping[str, int]
 default_options: frozenset[str]
 
 class ReaddirToken:
-    pass
+    plus: bool
 
 class RequestContext:
     @property

--- a/src/pyfuse3/__init__.pyx
+++ b/src/pyfuse3/__init__.pyx
@@ -1120,8 +1120,12 @@ def readdir_reply(ReaddirToken token, name, EntryAttributes attr, off_t next_id)
         token.buf = token.buf_start
 
     cname = PyBytes_AsString(name)
-    len_ = fuse_add_direntry_plus(token.req, token.buf, token.size,
-                                  cname, &attr.fuse_param, next_id)
+    if token.plus:
+        len_ = fuse_add_direntry_plus(token.req, token.buf, token.size,
+                                      cname, &attr.fuse_param, next_id)
+    else:
+        len_ = fuse_add_direntry(token.req, token.buf, token.size,
+                                 cname, &attr.fuse_param.attr, next_id)
     if len_ > token.size:
         return False
 

--- a/src/pyfuse3/_pyfuse3.py
+++ b/src/pyfuse3/_pyfuse3.py
@@ -509,11 +509,27 @@ class Operations:
 
         Instead of returning the directory entries directly, the method must
         call `readdir_reply` for each directory entry. If `readdir_reply`
-        returns True, the file system must increase the lookup count for the
-        provided directory entry by one and call `readdir_reply` again for the
-        next entry (if any). If `readdir_reply` returns False, the lookup count
-        must *not* be increased and the method should return without further
-        calls to `readdir_reply`.
+        returns True, the file system should call `readdir_reply` again for the
+        next entry (if any). If `readdir_reply` returns False, the method should
+        return without further calls to `readdir_reply`.
+
+        Whether reporting an entry takes a kernel lookup reference (and so
+        requires the file system to increase that inode's lookup count) depends
+        on how the client requested the listing. This is exposed as the
+        read-only `ReaddirToken.plus` attribute:
+
+        - If *token* ``.plus`` is True (the request was ``FUSE_READDIRPLUS``,
+          which is what a normal Linux kernel always sends), then each entry for
+          which `readdir_reply` returns True takes an implicit lookup reference,
+          and the file system *must* increase that inode's lookup count by one.
+        - If *token* ``.plus`` is False (the request was a plain
+          ``FUSE_READDIR``, which some clients such as gVisor's sentry send),
+          the kernel takes no lookup reference for the reported entries, so the
+          file system must *not* increase the lookup count. Increasing it would
+          leak the inode, as no `forget` will ever balance it.
+
+        In either case, if `readdir_reply` returns False the lookup count must
+        *not* be increased for that entry.
 
         The *start_id* parameter will be either zero (in which case listing
         should begin with the first entry) or it will correspond to a value that

--- a/src/pyfuse3/handlers.pxi
+++ b/src/pyfuse3/handlers.pxi
@@ -29,10 +29,14 @@ cdef class _Container:
     cdef size_t   size
     cdef struct_stat stat
     cdef uint64_t fh
+    cdef bint readdir_plain
 
 cdef void fuse_init (void *userdata, fuse_conn_info *conn):
-    if not conn.capable & FUSE_CAP_READDIRPLUS:
-        raise RuntimeError('Kernel too old, pyfuse3 requires kernel 3.9 or newer!')
+    # A client that supports FUSE_CAP_READDIRPLUS still issues plain
+    # FUSE_READDIR when it wants entries without attributes, and some clients
+    # (e.g. gVisor's sentry) implement only plain FUSE_READDIR. We register
+    # both operations and never require READDIRPLUS, so there is nothing to
+    # negotiate here beyond disabling the "auto" heuristic below.
     conn.want &= ~(<unsigned> FUSE_CAP_READDIRPLUS_AUTO)
 
     if (operations.supports_dot_lookup and
@@ -564,6 +568,7 @@ cdef class ReaddirToken:
     cdef char *buf_start
     cdef char *buf
     cdef size_t size
+    cdef readonly bint plus
 
 cdef void fuse_readdirplus (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
                             fuse_file_info *fi):
@@ -575,12 +580,24 @@ cdef void fuse_readdirplus (fuse_req_t req, fuse_ino_t ino, size_t size, off_t o
     c.fh = fi.fh
     save_retval(fuse_readdirplus_async(c))
 
+cdef void fuse_readdir (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
+                        fuse_file_info *fi):
+    global py_retval
+    cdef _Container c = _Container()
+    c.req = req
+    c.size = size
+    c.off = off
+    c.fh = fi.fh
+    c.readdir_plain = True
+    save_retval(fuse_readdirplus_async(c))
+
 async def fuse_readdirplus_async (_Container c):
     cdef int ret
     cdef ReaddirToken token = ReaddirToken()
     token.buf_start = NULL
     token.size = c.size
     token.req = c.req
+    token.plus = not c.readdir_plain
 
     try:
         await operations.readdir(c.fh, c.off, token)

--- a/src/pyfuse3/internal.pxi
+++ b/src/pyfuse3/internal.pxi
@@ -57,6 +57,7 @@ cdef void init_fuse_ops():
     fuse_ops.release = fuse_release
     fuse_ops.fsync = fuse_fsync
     fuse_ops.opendir = fuse_opendir
+    fuse_ops.readdir = fuse_readdir
     fuse_ops.readdirplus = fuse_readdirplus
     fuse_ops.releasedir = fuse_releasedir
     fuse_ops.fsyncdir = fuse_fsyncdir

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -87,6 +87,15 @@ def _mount_fs(tmpdir, fs_class):
             umount(mount_process, mnt_dir)
 
 
+def test_readdir(testfs):
+    (mnt_dir, fs_state) = testfs
+    # Exercises opendir + readdir inside the mounted daemon. This also runs the
+    # ``assert token.plus is True`` invariant in Fs.readdir, confirming that a
+    # normal kernel negotiates FUSE_READDIRPLUS and that ReaddirToken.plus is
+    # readable from Python.
+    assert os.listdir(mnt_dir) == ['message']
+
+
 def test_invalidate_entry(testfs):
     (mnt_dir, fs_state) = testfs
     path = os.path.join(mnt_dir, 'message')
@@ -275,6 +284,10 @@ class Fs(pyfuse3.Operations):
 
     async def readdir(self, fh: FileHandleT, start_id: int, token: ReaddirToken) -> None:
         assert fh == pyfuse3.ROOT_INODE
+        # A normal Linux kernel always negotiates FUSE_READDIRPLUS, so token.plus
+        # must be True here. The plain-readdir path (token.plus is False) can only
+        # be reached with a client that issues FUSE_READDIR, such as gVisor.
+        assert token.plus is True
         if start_id == 0:
             pyfuse3.readdir_reply(token, self.hello_name, await self.getattr(self.hello_inode), 1)
         return


### PR DESCRIPTION
## Problem

pyfuse3 cannot be used at all under a FUSE client that implements plain
`FUSE_READDIR` but not `FUSE_READDIRPLUS`. Two independent things break:

1. **Init aborts.** `fuse_init` raises `RuntimeError('Kernel too old, pyfuse3
   requires kernel 3.9 or newer!')` whenever the connection does not advertise
   `FUSE_CAP_READDIRPLUS`, so the mount never comes up.

2. **Plain readdir is unimplemented.** pyfuse3 registers only
   `fuse_ops.readdirplus`. A client that issues a plain `FUSE_READDIR` hits a
   NULL operation and libfuse answers `ENOSYS`, so directory listings fail even
   if init is bypassed.

The motivating client is [gVisor](https://gvisor.dev/)'s sentry, whose VFS
implements plain `FUSE_READDIR` but not `FUSE_READDIRPLUS`
([google/gvisor#3404](https://github.com/google/gvisor/issues/3404), open since
2020). Running any pyfuse3 filesystem inside a gVisor sandbox is currently
impossible.

Plain `FUSE_READDIR` (opcode 28) is the mandatory FUSE baseline;
`FUSE_READDIRPLUS` (opcode 44, FUSE 7.21 / Linux 3.9) is a negotiated
optimization that bundles each entry's attributes to save a follow-up `LOOKUP`.
libfuse treats them as independent, optional vtable slots — its own
`hello_ll.c` implements only plain readdir, and `passthrough_ll.c` implements
both and branches on a `plus` flag.

## Fix

- **Register both operations.** `fuse_ops.readdir` is now registered alongside
  `fuse_ops.readdirplus`; the client's opcode selects which is invoked. No new
  init/`Operations` flag is introduced — the client already advertises what it
  supports, so auto-detection is the right axis.
- **Stop requiring READDIRPLUS.** `fuse_init` no longer raises when
  `FUSE_CAP_READDIRPLUS` is absent. (`FUSE_CAP_READDIRPLUS_AUTO` is still
  cleared, so a capable Linux client keeps sending READDIRPLUS.)
- **Share one async path.** Both entry points funnel into the existing
  `fuse_readdirplus_async`. A new read-only attribute `ReaddirToken.plus`
  records which request the client made, and `readdir_reply` emits
  `fuse_add_direntry` (plain) or `fuse_add_direntry_plus` accordingly.

## Correctness — lookup counts

READDIRPLUS entries take an implicit per-entry kernel lookup reference (balanced
later by `FORGET`); plain READDIR entries take none. The `Operations.readdir`
contract therefore now depends on `token.plus`:

- `token.plus is True` → each entry for which `readdir_reply` returns True takes
  a lookup reference; the filesystem **must** increase the inode's lookup count
  (unchanged behaviour).
- `token.plus is False` → the kernel takes no reference; the filesystem **must
  not** increase the lookup count, or the inode leaks with no balancing
  `FORGET`.

This is documented on `Operations.readdir` and applied in the `passthroughfs`
example (its `_add_path` bookkeeping is now gated on `token.plus`).

## Compatibility

Inert on Linux. A normal Linux kernel always negotiates READDIRPLUS, so
`token.plus` is always True, the new plain-readdir callback is never invoked,
and byte-for-byte behaviour is unchanged. The only public surface added is one
read-only attribute (`ReaddirToken.plus`); no handler signature changes.

## Testing

- **No-regression (CI).** The full `test/` suite passes unchanged. `Fs.readdir`
  now asserts `token.plus is True` (a normal kernel never sends plain
  `FUSE_READDIR`), and a new `test_readdir` forces `opendir`+`readdir` through a
  real listing so the assertion and the new attribute are exercised from Python.
  A stock kernel cannot drive the plain-readdir branch, so CI proves only that
  nothing regresses — see below for the branch's real coverage.
- **Plain-readdir branch (under gVisor).** Verified by building the patched
  wheel and running a pyfuse3 hello filesystem inside a gVisor (`runsc`)
  sandbox. Before/after transcript, same code, same image:

  ```
  # BEFORE (stock) — mount fails, listing impossible
  $ runsc do -- python3 hello.py /tmp/mp & ls /tmp/mp; cat /tmp/mp/hello
  cat: /tmp/mp/hello: Transport endpoint is not connected
  RuntimeError: Kernel too old, pyfuse3 requires kernel 3.9 or newer!
      at src/pyfuse3/handlers.pxi:35 in fuse_init

  # AFTER (patched) — listing and read succeed
  $ runsc do -- python3 hello.py /tmp/mp & ls /tmp/mp; cat /tmp/mp/hello
  hello
  ls_exit=0
  Hello World from pyfuse3!
  cat_exit=0
  # daemon stderr: readdir called: token.plus=False   (plain FUSE_READDIR branch)

  # CONTROL (patched, normal Linux kernel via runc) — unchanged
  hello
  Hello World from pyfuse3!
  # daemon stderr: readdir called: token.plus=True     (READDIRPLUS still negotiated)
  ```

## Open question

Happy to add a lower-level `readdir_reply(..)` unit test that constructs a
`token` with `plus=False` and asserts a plain `fuse_dirent` record is emitted,
if you'd prefer in-CI coverage of the plain path. It's fragile to build outside
a live request, so I left it out — let me know your preference.
